### PR TITLE
fhir_auth export package consistency

### DIFF
--- a/fhir_auth/example/ios/Flutter/Debug.xcconfig
+++ b/fhir_auth/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_auth/example/ios/Flutter/Release.xcconfig
+++ b/fhir_auth/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_auth/example/ios/Podfile
+++ b/fhir_auth/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/fhir_auth/lib/dstu2.dart
+++ b/fhir_auth/lib/dstu2.dart
@@ -2,3 +2,4 @@ export 'package:dartz/dartz.dart' show Tuple3;
 export 'dstu2/fhir_client.dart';
 export 'dstu2/gcs_client.dart';
 export 'dstu2/scopes.dart';
+export 'dstu2/smart_client.dart';

--- a/fhir_auth/lib/r4.dart
+++ b/fhir_auth/lib/r4.dart
@@ -2,3 +2,4 @@ export 'package:dartz/dartz.dart' show Tuple3;
 export 'r4/fhir_client.dart';
 export 'r4/gcs_client.dart';
 export 'r4/scopes.dart';
+export 'r4/smart_client.dart';

--- a/fhir_auth/lib/r5.dart
+++ b/fhir_auth/lib/r5.dart
@@ -2,3 +2,4 @@ export 'package:dartz/dartz.dart' show Tuple3;
 export 'r5/fhir_client.dart';
 export 'r5/gcs_client.dart';
 export 'r5/scopes.dart';
+export 'r5/smart_client.dart';

--- a/fhir_auth/lib/stu3.dart
+++ b/fhir_auth/lib/stu3.dart
@@ -2,3 +2,4 @@ export 'package:dartz/dartz.dart' show Tuple3;
 export 'stu3/fhir_client.dart';
 export 'stu3/gcs_client.dart';
 export 'stu3/scopes.dart';
+export 'stu3/smart_client.dart';

--- a/fhir_db/example/ios/Flutter/Debug.xcconfig
+++ b/fhir_db/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_db/example/ios/Flutter/Release.xcconfig
+++ b/fhir_db/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_db/example/ios/Podfile
+++ b/fhir_db/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/fhir_db/example/pubspec.lock
+++ b/fhir_db/example/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -264,7 +264,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -556,14 +556,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: transitive
     description:
@@ -614,5 +614,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.22.2"
+  dart: ">=2.10.2 <2.11.0"
+  flutter: ">=1.22.2 <2.0.0"

--- a/fhir_db/pubspec.lock
+++ b/fhir_db/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -131,7 +131,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: "direct main"
     description:
@@ -276,14 +276,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.0-nullsafety.3"
   win32:
     dependency: transitive
     description:
@@ -306,5 +306,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.22.2"
+  dart: ">=2.10.2 <2.11.0"
+  flutter: ">=1.22.2 <2.0.0"

--- a/fhir_store/fhir_store_demo/ios/Flutter/Debug.xcconfig
+++ b/fhir_store/fhir_store_demo/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_store/fhir_store_demo/ios/Flutter/Release.xcconfig
+++ b/fhir_store/fhir_store_demo/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/fhir_store/fhir_store_demo/ios/Podfile
+++ b/fhir_store/fhir_store_demo/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end


### PR DESCRIPTION
This was a minor change to include `export 'VERSION_NUMBER/smart_client.dart';` in each export library for consistency. This way, you simply need to call `import 'package:fhir_auth/r4.dart';` regardless of the class you need within this package. 

Also regarding consistency, Podfile and similar iOS related files were added to the `example` folders of the packages that did not have them.